### PR TITLE
Deploying the portofolio website freely using the GitHub pages tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - npm, npx,Linters
 
 ## Live Domo
+
 [Live demo](https://joseph07-drack.github.io/Portofolio/)
 
 ## Getting Started

--- a/index.html
+++ b/index.html
@@ -266,7 +266,7 @@
             <li>
               <a href="#"
                 ><img
-                  src="/img/icons/angellist.svg"
+                  src="img/icons/angellist.svg"
                   alt="angellist"
                   title="follow me on"
               /></a>


### PR DESCRIPTION
For this practical session, I learned to deploy my portfolio website using the GitHub pages tool to let people visit it online.

-Since I deploy this project before, I realized that some images and icons were not showing up, and I tried to fix the issue.
-To see the **live demo** check the **Live Demo** heading from the README.md file or just click [here](https://joseph07-drack.github.io/Portofolio/).