### PR TITLE
Add google analytics script to the portfolio website

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,5 +362,20 @@
         </div>
       </section>
     </div>
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script
+      async
+      src="https://www.googletagmanager.com/gtag/js?id=299769493"
+    ></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag() {
+        window.dataLayer.push(arguments);
+      }
+      gtag("js", new Date());
+
+      gtag("config", "299769493");
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Add a google analytics script to the portfolio website to monitor activities or traffic that will be going on the portfolio to provide some clues on the way of improving it.